### PR TITLE
Added split transparency support for neovim

### DIFF
--- a/autoload/background.vim
+++ b/autoload/background.vim
@@ -47,7 +47,7 @@ function! background#clear_background()
     if g:clear_background
         if !exists('g:transparent_groups')
             let g:transparent_groups = 
-                        \['Normal', 'Comment', 'Constant', 'Special', 'Identifier',
+                        \['Normal', 'NormalNC', 'Comment', 'Constant', 'Special', 'Identifier',
                         \'Statement', 'PreProc', 'Type', 'Underlined', 'Todo', 'String',
                         \'Function', 'Conditional', 'Repeat', 'Operator', 'Structure',
                         \'LineNr', 'NonText', 'SignColumn', 'CursorLineNr', 'EndOfBuffer']


### PR DESCRIPTION
The NormalNC highlight group only exists for neovim and must be configured to enable transparency for splits that are not currently active. This PR adds that configuration.

I have tested that it fixes the issue for neovim in WSL on Windows, and that it doesn't cause issues in gvim on Windows, not sure whether more environments need to be tested, this in theory covers the core environments.

Advise on if the formatting needs adjusting as a result of the change.